### PR TITLE
initialize() method only supports the "models" parameter as an array

### DIFF
--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -303,7 +303,7 @@
         state.firstPage :
         state.currentPage;
 
-      if (!_.isArray(models)) models = models ? [models] : [];
+      if (!_isArray(models)) models = models ? [models] : [];
 
       if (mode != "server" && state.totalRecords == null && !_isEmpty(models)) {
         state.totalRecords = models.length;

--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -303,6 +303,8 @@
         state.firstPage :
         state.currentPage;
 
+      if (!_.isArray(models)) models = models ? [models] : [];
+
       if (mode != "server" && state.totalRecords == null && !_isEmpty(models)) {
         state.totalRecords = models.length;
       }

--- a/test/client-pageable.js
+++ b/test/client-pageable.js
@@ -80,6 +80,14 @@ $(document).ready(function () {
 
     var mods = models.slice();
 
+    col = new Backbone.PageableCollection(mods[0], {
+      mode: "client"
+    });
+
+    strictEqual(col.state.totalRecords, 1);
+    strictEqual(col.fullCollection.size(), 1);
+    strictEqual(col.fullCollection.at(0).get("name"), "a");
+
     col = new Backbone.PageableCollection(mods, {
       comparator: comparator,
       state: {


### PR DESCRIPTION
In the [initialize](https://github.com/wyuenho/backbone-pageable/blob/master/lib/backbone-pageable.js#L283) method, the "models" parameter is considered an array. The thing is, in a plain backbone collection, I can do something like:

``` javascript
var collection = new Backbone.Collection({hello: 'world'})
```

and it will instantiate the collection with a single model in it.

But if I do this with a pageable collection, I get errors because an object is not expected.
