### PR TITLE
Pass options from parse to parseState

### DIFF
--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -992,11 +992,12 @@
        encouraged to override #parseState and #parseRecords instead.
 
        @param {Object} resp The deserialized response data from the server.
+       @param {Object} the options for the ajax request
 
        @return {Array.<Object>} An array of model objects
     */
-    parse: function (resp) {
-      var newState = this.parseState(resp, _clone(this.queryParams), _clone(this.state));
+    parse: function (resp, options) {
+      var newState = this.parseState(resp, _clone(this.queryParams), _clone(this.state), options);
       if (newState) this.state = this._checkState(_extend({}, this.state, newState));
       return this.parseRecords(resp);
     },
@@ -1016,8 +1017,15 @@
        `totalRecords` value is enough to trigger a full pagination state
        recalculation.
 
-           parseState: function (resp, queryParams, state) {
+           parseState: function (resp, queryParams, state, options) {
              return {totalRecords: resp.total_entries};
+           }
+
+       If you want to use header fields use:
+
+
+           parseState: function (resp, queryParams, state, options) {
+               return {totalRecords: options.xhr.getResponseHeader("X-total")};
            }
 
        This method __MUST__ return a new state object instead of directly
@@ -1027,10 +1035,11 @@
        @param {Object} resp The deserialized response data from the server.
        @param {Object} queryParams A copy of #queryParams.
        @param {Object} state A copy of #state.
+       @param {Object} the options passed through from the parse function
 
        @return {Object} A new (partial) state object.
      */
-    parseState: function (resp, queryParams, state) {
+    parseState: function (resp, queryParams, state, options) {
       if (resp && resp.length === 2 && _isObject(resp[0]) && _isArray(resp[1])) {
 
         var newState = _clone(state);


### PR DESCRIPTION
I have been toying around with a web service that passes `total`, `limit` and `offset` values as header fields. To set the correct `totalRecords` I need to have access to the `xhr` which backbone passes to the `parse` function via an options object. Those options I pass then to `parseState`.
