### PR TITLE
Add ability to override base Backbone.Collection

### DIFF
--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -93,6 +93,7 @@
 
   var PARAM_TRIM_RE = /[\s'"]/g;
   var URL_TRIM_RE = /[<>\s'"]/g;
+  var BaseCollection = Backbone.Collection;
 
   /**
      Drop-in replacement for Backbone.Collection. Supports server-side and
@@ -256,7 +257,7 @@
     */
     constructor: function (models, options) {
 
-      Backbone.Collection.apply(this, arguments);
+      BaseCollection.apply(this, arguments);
 
       options = options || {};
 


### PR DESCRIPTION
Currently, if you attempt to set Backbone.Collection to PageableCollection it triggers an infinite loop, because of how Backbone.Collection is referenced in the constructor. This properly references the Collection constructor to prevent this.
