### PR TITLE
remove '.' character in header to fix broken hyperlink

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ The following examples utilizes `Backgrid.js
 Installation
 ------------
 
-Installing from Node.js
+Installing from Node js
 +++++++++++++++++++++++
 
 .. code-block:: bash


### PR DESCRIPTION
A bug (see: https://github.com/github/markup/issues/71) generates invalid hyperlinks in the table of contents for headers with a `.` character in them.
