### PR TITLE
Rename hasNext to hasNextPage and hasPrevious to hasPreviousPage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ Method                   Use When
 ``switchMode``           Switching between modes
 ``state``                Need to read the internal state
 ``get*Page``             Need to go to a different page
-``hasPrevious, hasNext`` Check if paging backward or forward is possible
+``hasPreviousPage, hasNextPage`` Check if paging backward or forward is possible
 ======================== ===============================================
 
 In addition to the above methods, you can also synchronize the state with the

--- a/examples/js/extensions/paginator/backgrid-paginator.js
+++ b/examples/js/extensions/paginator/backgrid-paginator.js
@@ -166,8 +166,8 @@
       var pageIndex = this.pageIndex;
 
       if (this.isRewind && currentPage == state.firstPage ||
-         this.isBack && !collection.hasPrevious() ||
-         this.isForward && !collection.hasNext() ||
+         this.isBack && !collection.hasPreviousPage() ||
+         this.isForward && !collection.hasNextPage() ||
          this.isFastForward && (currentPage == state.lastPage || state.totalPages < 1)) {
         this.$el.addClass("disabled");
       }

--- a/examples/js/extensions/paginator/backgrid-paginator.js
+++ b/examples/js/extensions/paginator/backgrid-paginator.js
@@ -166,8 +166,8 @@
       var pageIndex = this.pageIndex;
 
       if (this.isRewind && currentPage == state.firstPage ||
-         this.isBack && !collection.hasPreviousPage() ||
-         this.isForward && !collection.hasNextPage() ||
+         this.isBack && !collection.hasPrevious() ||
+         this.isForward && !collection.hasNext() ||
          this.isFastForward && (currentPage == state.lastPage || state.totalPages < 1)) {
         this.$el.addClass("disabled");
       }

--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -753,6 +753,16 @@
     },
 
     /**
+       Delegates to hasPreviousPage.
+    */
+    hasPrevious: function () {
+      var msg = "hasPrevious has been deprecated, use hasPreviousPage instead";
+      console && console.warn && console.warn(msg);
+
+      return this.hasPreviousPage();
+    },
+
+    /**
        @return {boolean} `true` if this collection can page forward, `false`
        otherwise.
     */
@@ -761,6 +771,16 @@
       var currentPage = this.state.currentPage;
       if (this.mode != "infinite") return currentPage < state.lastPage;
       return !!this.links[currentPage + 1];
+    },
+
+    /**
+       Delegates to hasNextPage.
+    */
+    hasNext: function () {
+      var msg = "hasNext has been deprecated, use hasNextPage instead";
+      console && console.warn && console.warn(msg);
+
+      return this.hasNextPage();
     },
 
     /**

--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -745,7 +745,7 @@
        @return {boolean} `true` if this collection can page backward, `false`
        otherwise.
     */
-    hasPrevious: function () {
+    hasPreviousPage: function () {
       var state = this.state;
       var currentPage = state.currentPage;
       if (this.mode != "infinite") return currentPage > state.firstPage;
@@ -756,7 +756,7 @@
        @return {boolean} `true` if this collection can page forward, `false`
        otherwise.
     */
-    hasNext: function () {
+    hasNextPage: function () {
       var state = this.state;
       var currentPage = this.state.currentPage;
       if (this.mode != "infinite") return currentPage < state.lastPage;

--- a/lib/backbone-pageable.js
+++ b/lib/backbone-pageable.js
@@ -757,7 +757,7 @@
     */
     hasPrevious: function () {
       var msg = "hasPrevious has been deprecated, use hasPreviousPage instead";
-      console && console.warn && console.warn(msg);
+      typeof console != 'undefined' && console.warn && console.warn(msg);
 
       return this.hasPreviousPage();
     },
@@ -778,7 +778,7 @@
     */
     hasNext: function () {
       var msg = "hasNext has been deprecated, use hasNextPage instead";
-      console && console.warn && console.warn(msg);
+      typeof console != 'undefined' && console.warn && console.warn(msg);
 
       return this.hasNextPage();
     },

--- a/test/client-pageable.js
+++ b/test/client-pageable.js
@@ -944,6 +944,29 @@ $(document).ready(function () {
     strictEqual(col.hasNextPage(), false);
   });
 
+  // Just a duplicate of the above
+  test("deprecated hasNext and hasPrevious", function () {
+    var col = new Backbone.PageableCollection(models, {
+      state: {
+        pageSize: 1
+      },
+      mode: "client"
+    });
+
+    strictEqual(col.hasPrevious(), false);
+    strictEqual(col.hasNext(), true);
+
+    col.getNextPage();
+
+    strictEqual(col.hasPrevious(), true);
+    strictEqual(col.hasNext(), true);
+
+    col.getLastPage();
+
+    strictEqual(col.hasPrevious(), true);
+    strictEqual(col.hasNext(), false);
+  });
+
   test("parsing from constructor #112", function () {
     var Model = Backbone.Model.extend({
       parse: function (raw) {

--- a/test/client-pageable.js
+++ b/test/client-pageable.js
@@ -922,30 +922,8 @@ $(document).ready(function () {
     strictEqual(col.state.totalPages, 1);
   });
 
-  test("hasNextPage and hasPreviousPage", function () {
-    var col = new Backbone.PageableCollection(models, {
-      state: {
-        pageSize: 1
-      },
-      mode: "client"
-    });
-
-    strictEqual(col.hasPreviousPage(), false);
-    strictEqual(col.hasNextPage(), true);
-
-    col.getNextPage();
-
-    strictEqual(col.hasPreviousPage(), true);
-    strictEqual(col.hasNextPage(), true);
-
-    col.getLastPage();
-
-    strictEqual(col.hasPreviousPage(), true);
-    strictEqual(col.hasNextPage(), false);
-  });
-
-  // Just a duplicate of the above
-  test("deprecated hasNext and hasPrevious", function () {
+  // emits some deprecation warnings
+  test("hasNext and hasPrevious", function () {
     var col = new Backbone.PageableCollection(models, {
       state: {
         pageSize: 1

--- a/test/client-pageable.js
+++ b/test/client-pageable.js
@@ -922,7 +922,7 @@ $(document).ready(function () {
     strictEqual(col.state.totalPages, 1);
   });
 
-  test("hasNext and hasPrevious", function () {
+  test("hasNextPage and hasPreviousPage", function () {
     var col = new Backbone.PageableCollection(models, {
       state: {
         pageSize: 1
@@ -930,18 +930,18 @@ $(document).ready(function () {
       mode: "client"
     });
 
-    strictEqual(col.hasPrevious(), false);
-    strictEqual(col.hasNext(), true);
+    strictEqual(col.hasPreviousPage(), false);
+    strictEqual(col.hasNextPage(), true);
 
     col.getNextPage();
 
-    strictEqual(col.hasPrevious(), true);
-    strictEqual(col.hasNext(), true);
+    strictEqual(col.hasPreviousPage(), true);
+    strictEqual(col.hasNextPage(), true);
 
     col.getLastPage();
 
-    strictEqual(col.hasPrevious(), true);
-    strictEqual(col.hasNext(), false);
+    strictEqual(col.hasPreviousPage(), true);
+    strictEqual(col.hasNextPage(), false);
   });
 
   test("parsing from constructor #112", function () {

--- a/test/infinite-pageable.js
+++ b/test/infinite-pageable.js
@@ -280,4 +280,33 @@ $(document).ready(function () {
     strictEqual(col.hasNextPage(), false);
   });
 
+  // Just a duplicate of the above
+  test("deprecated hasNext and hasPrevious", function () {
+    var col = new (Backbone.PageableCollection.extend({
+      url: "url"
+    }))([
+      {id: 1},
+      {id: 2},
+      {id: 3}
+    ], {
+      state: {
+        pageSize: 1
+      },
+      mode: "infinite"
+    });
+
+    strictEqual(col.hasPrevious(), false);
+    strictEqual(col.hasNext(), true);
+
+    col.getNextPage();
+
+    strictEqual(col.hasPrevious(), true);
+    strictEqual(col.hasNext(), true);
+
+    col.getLastPage();
+
+    strictEqual(col.hasPrevious(), true);
+    strictEqual(col.hasNext(), false);
+  });
+
 });

--- a/test/infinite-pageable.js
+++ b/test/infinite-pageable.js
@@ -252,7 +252,7 @@ $(document).ready(function () {
     col.parseLinks.restore();
   });
 
-  test("hasNext and hasPrevious", function () {
+  test("hasNextPage and hasPreviousPage", function () {
     var col = new (Backbone.PageableCollection.extend({
       url: "url"
     }))([
@@ -266,18 +266,18 @@ $(document).ready(function () {
       mode: "infinite"
     });
 
-    strictEqual(col.hasPrevious(), false);
-    strictEqual(col.hasNext(), true);
+    strictEqual(col.hasPreviousPage(), false);
+    strictEqual(col.hasNextPage(), true);
 
     col.getNextPage();
 
-    strictEqual(col.hasPrevious(), true);
-    strictEqual(col.hasNext(), true);
+    strictEqual(col.hasPreviousPage(), true);
+    strictEqual(col.hasNextPage(), true);
 
     col.getLastPage();
 
-    strictEqual(col.hasPrevious(), true);
-    strictEqual(col.hasNext(), false);
+    strictEqual(col.hasPreviousPage(), true);
+    strictEqual(col.hasNextPage(), false);
   });
 
 });

--- a/test/infinite-pageable.js
+++ b/test/infinite-pageable.js
@@ -252,36 +252,8 @@ $(document).ready(function () {
     col.parseLinks.restore();
   });
 
-  test("hasNextPage and hasPreviousPage", function () {
-    var col = new (Backbone.PageableCollection.extend({
-      url: "url"
-    }))([
-      {id: 1},
-      {id: 2},
-      {id: 3}
-    ], {
-      state: {
-        pageSize: 1
-      },
-      mode: "infinite"
-    });
-
-    strictEqual(col.hasPreviousPage(), false);
-    strictEqual(col.hasNextPage(), true);
-
-    col.getNextPage();
-
-    strictEqual(col.hasPreviousPage(), true);
-    strictEqual(col.hasNextPage(), true);
-
-    col.getLastPage();
-
-    strictEqual(col.hasPreviousPage(), true);
-    strictEqual(col.hasNextPage(), false);
-  });
-
-  // Just a duplicate of the above
-  test("deprecated hasNext and hasPrevious", function () {
+  // emits some deprecation warnings
+  test("hasNext and hasPrevious", function () {
     var col = new (Backbone.PageableCollection.extend({
       url: "url"
     }))([


### PR DESCRIPTION
I noticed a disparity between `getNextPage` and `hasNext` functions. I hope that with this fix, they will look a little more symmetrical.

Still TODO (I will need some help with these):
- [x] make sure the tests pass (I couldn't find anything in the README on how to run the tests)
- [x] delegate `has*` to `has*Page`
- [x] emit deprecation warnings on `has*`
